### PR TITLE
Remove compile error when this library is used elsewhere.

### DIFF
--- a/src/clj_oauth2/client.clj
+++ b/src/clj_oauth2/client.clj
@@ -1,4 +1,5 @@
 (ns clj-oauth2.client
+  (:refer-clojure :exclude [get])
   (:use [clj-http.client :only [wrap-request]]
         [clojure.data.json :only [read-json]]
         [clj-oauth2.uri])


### PR DESCRIPTION
Hi Max,

I was trying to compile your clj-facebook-graph.example and got this -
WARNING: get already refers to: #'clojure.core/get in namespace: clj-oauth2.client

and then some exception. I hope this fix should remove that error.
Please merge this if you think this is correct.

Regards,
Manoj.
