### PR TITLE
Add Support for re-authentication of the access-token with Google

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,5 +2,15 @@
 /lib
 /classes
 pom.xml
-*jar
+*.jar
+*.class
+*.swp
+*.swo
+*.out
 .lein-deps-sum
+.lein-failures
+.lein-plugins
+.lein-repl-history
+.nrepl-port
+.DS_Store
+#README.md#

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
+/target
+/lib
+/classes
 pom.xml
 *jar
-/lib/
-/classes/
 .lein-deps-sum

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 0.4.0
+
+* added `refresh-access-token` to get new token from Google
+* added support for additional elements of the config for handling the
+  infrastructure for `refresh-access-token`
+
 ## 0.3.0
 
 * support OAuth 2.0 draft 10 for Force.com

--- a/project.clj
+++ b/project.clj
@@ -1,7 +1,7 @@
 (def dev-dependencies
   '[[ring "0.3.11"]])
 
-(defproject clj-oauth2 "0.3.0"
+(defproject clj-oauth2 "0.4.0"
   :description "clj-http and ring middlewares for OAuth 2.0"
   :dependencies [[org.clojure/clojure "1.3.0"]
                  [org.clojure/data.json "0.1.1"]

--- a/src/clj_oauth2/client.clj
+++ b/src/clj_oauth2/client.clj
@@ -122,7 +122,8 @@
       (nil? refresh-token)
         (throw (OAuth2Exception. (format "No :refresh-token in %s" token)))
       :else
-        (request-access-token (assoc endpoint :grant-type "refresh_token") token))))
+        (-> (request-access-token (assoc endpoint :grant-type "refresh_token") token)
+          (assoc :refresh-token refresh-token)))))
 
 (defn with-access-token
   [uri {:keys [access-token query-param]}]

--- a/src/clj_oauth2/client.clj
+++ b/src/clj_oauth2/client.clj
@@ -1,4 +1,5 @@
 (ns clj-oauth2.client
+  "The basic client functions for OAuth2 authentication."
   (:refer-clojure :exclude [get])
   (:use [clj-http.client :only [wrap-request]]
         [clojure.data.json :only [read-json]])
@@ -9,8 +10,7 @@
            [org.apache.commons.codec.binary Base64]))
 
 (defn make-auth-request
-  [{:keys [authorization-uri client-id client-secret redirect-uri scope]}
-   & [state]]
+  [{:keys [authorization-uri client-id client-secret redirect-uri scope approval-prompt access-type]} & [state]]
   (let [uri (uri/uri->map (uri/make authorization-uri) true)
         query (assoc (:query uri)
                 :client_id client-id
@@ -19,7 +19,9 @@
         query (if state (assoc query :state state) query)
         query (if scope
                 (assoc query :scope (str/join " " scope))
-                query)]
+                query)
+        query (if approval-prompt (assoc query :approval_prompt approval-prompt) query)
+        query (if access-type (assoc query :access_type access-type) query)]
     {:uri (str (uri/make (assoc uri :query query)))
      :scope scope
      :state state}))
@@ -38,10 +40,13 @@
 (defmethod prepare-access-token-request
   "authorization_code" [request endpoint params]
   (merge-with merge request
-              {:body {:code
-                      (:code params)
-                      :redirect_uri
-                      (:redirect-uri endpoint)}}))
+              {:body {:code         (:code params)
+                      :redirect_uri (:redirect-uri endpoint)}}))
+
+(defmethod prepare-access-token-request
+  "refresh_token" [request endpoint params]
+  (merge-with merge request
+              {:body {:refresh_token (:refresh-token params)}}))
 
 (defmethod prepare-access-token-request
   "password" [request endpoint params]
@@ -52,24 +57,17 @@
 (defn- add-client-authentication [request endpoint]
   (let [{:keys [client-id client-secret authorization-header?]} endpoint]
     (if authorization-header?
-      (add-base64-auth-header
-       request
-       "Basic"
-       (str client-id ":" client-secret))
-      (merge-with
-       merge
-       request
-       {:body
-        {:client_id client-id
-         :client_secret client-secret}}))))
+      (add-base64-auth-header request "Basic" (str client-id ":" client-secret))
+      (merge-with merge request
+                  {:body {:client_id     client-id
+                          :client_secret client-secret}}))))
 
 (defn- request-access-token
   [endpoint params]
   (let [{:keys [access-token-uri access-query-param grant-type]} endpoint
-        request
-        {:content-type "application/x-www-form-urlencoded"
-         :throw-exceptions false
-         :body {:grant_type grant-type}}
+        request {:content-type "application/x-www-form-urlencoded"
+                 :throw-exceptions false
+                 :body {:grant_type grant-type}}
         request (prepare-access-token-request request endpoint params)
         request (add-client-authentication request endpoint)
         request (update-in request [:body] uri/form-url-encode)
@@ -80,7 +78,8 @@
                           (.startsWith content-type "text/javascript"))) ; Facebookism
                (read-json body)
                (uri/form-url-decode body)) ; Facebookism
-        error (:error body)]
+        error (:error body)
+        refresh-token (:refresh_token body)]
     (if (or error (not= status 200))
       (throw (OAuth2Exception. (if error
                                  (if (string? error)
@@ -90,29 +89,43 @@
                                (if error
                                  (if (string? error)
                                    error
-                                   (:type error)) ; Facebookism 
+                                   (:type error)) ; Facebookism
                                  "unknown")))
-      {:access-token (:access_token body)
-       :token-type (or (:token_type body) "draft-10") ; Force.com
-       :query-param access-query-param
-       :params (dissoc body :access_token :token_type)})))
+      (-> {:access-token (:access_token body)
+           :token-type (or (:token_type body) "draft-10") ; Force.com
+           :query-param access-query-param
+           :params (dissoc body :access_token :refresh_token :token_type)}
+        (merge (if refresh-token {:refresh-token refresh-token}))))))
 
 (defn get-access-token
-  [endpoint 
-   & [params {expected-state :state expected-scope :scope}]]
+  [endpoint & [params {expected-state :state expected-scope :scope}]]
   (let [{:keys [state error]} params]
-    (cond (string? error)
-          (throw (OAuth2Exception. (:error_description params) error))
-          (and expected-state (not (= state expected-state)))
-          (throw (OAuth2StateMismatchException.
-                  (format "Expected state %s but got %s"
-                          state expected-state)
-                  state
-                  expected-state))
-          :else
-          (request-access-token endpoint params))))
+    (cond
+      (string? error)
+        (throw (OAuth2Exception. (:error_description params) error))
+      (and expected-state (not (= state expected-state)))
+        (throw (OAuth2StateMismatchException.
+                (format "Expected state %s but got %s"
+                        state expected-state)
+                state
+                expected-state))
+      :else
+        (request-access-token endpoint params))))
 
-(defn with-access-token [uri {:keys [access-token query-param]}]
+(defn refresh-access-token
+  "Function to take the existing `refresh-token` and configuration data
+  and refresh this token to make sure that we have a valid token to work
+  with."
+  [endpoint token]
+  (let [{:keys [refresh-token]} token]
+    (cond
+      (nil? refresh-token)
+        (throw (OAuth2Exception. (format "No :refresh-token in %s" token)))
+      :else
+        (request-access-token (assoc endpoint :grant-type "refresh_token") token))))
+
+(defn with-access-token
+  [uri {:keys [access-token query-param]}]
   (str (uri/make (assoc-in (uri/uri->map (uri/make uri) true)
                            [:query query-param]
                            access-token))))


### PR DESCRIPTION
We needed to have the ability to re-authenticate (renew) an `access-token` from an initial call to `get-access-token` when the token timed out. In order to do this, there needed to be a few additions to the `endpoint` map to hold the query parameters for Google to generate a `refresh-token`, and then we had to add the function to actually call the service to generate a new token.

At the same time, I added an example for Google usage, as that's what we're using, so that the _next_ guy won't have to do all this work that I needed to do to figure out how to get Google OAuth2 working.