### PR TITLE
Fix wrap-oauth2

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,7 +1,7 @@
 (def dev-dependencies
   '[[ring "0.3.11"]])
 
-(defproject clj-oauth2 "0.3.0"
+(defproject clj-oauth2 "0.3.1"
   :description "clj-http and ring middlewares for OAuth 2.0"
   :dependencies [[org.clojure/clojure "1.3.0"]
                  [org.clojure/data.json "0.1.1"]

--- a/src/clj_oauth2/ring.clj
+++ b/src/clj_oauth2/ring.clj
@@ -118,7 +118,8 @@ create a vector of values."
         oauth2-url-params (or (get oauth2-url-vector 1) "")
         encoding (or (:character-encoding request) "UTF-8")]
     (and (= oauth2-uri (request-uri request oauth2-params))
-         (submap? (keyify-params (parse-params oauth2-url-params encoding)) (:params request)))))
+         (submap? (keyify-params (parse-params oauth2-url-params encoding))
+                  (keyify-params (:params request))))))
 
 ;; This Ring wrapper acts as a filter, ensuring that the user has an OAuth
 ;; token for all but a set of explicitly excluded URLs. The response from
@@ -136,11 +137,11 @@ create a vector of values."
         ;; it in the response and redirect to the originally requested URL
         (let [response {:status 302
                         :headers {"Location" ((:get-target oauth2-params) request)}}
-              oauth2-data (oauth2/get-access-token 
-                           oauth2-params 
-                           (:params request) 
-                           (oauth2/make-auth-request 
-                            oauth2-params 
+              oauth2-data (oauth2/get-access-token
+                           oauth2-params
+                           (keyify-params (:params request))
+                           (oauth2/make-auth-request
+                            oauth2-params
                             ((:get-state oauth2-params) request)))]
           ((:put-oauth2-data oauth2-params) request response oauth2-data))
         ;; We're not handling the callback

--- a/src/clj_oauth2/ring.clj
+++ b/src/clj_oauth2/ring.clj
@@ -115,7 +115,7 @@ create a vector of values."
   "Returns true if this is a request to the callback URL"
   (let [oauth2-url-vector (string/split (.toString (java.net.URI. (:redirect-uri oauth2-params))) #"\?")
         oauth2-uri (nth oauth2-url-vector 0)
-        oauth2-url-params (nth oauth2-url-vector 1)
+        oauth2-url-params (or (get oauth2-url-vector 1) "")
         encoding (or (:character-encoding request) "UTF-8")]
     (and (= oauth2-uri (request-uri request oauth2-params))
          (submap? (keyify-params (parse-params oauth2-url-params encoding)) (:params request)))))


### PR DESCRIPTION
This fix includes three changes:
- Allow for a `:redirect-uri` that does not have any query parameters
- Allow for `wrap-params` implementations that set `:params` to a map with string keys (This is the norm in my experience)
- Bump the version number from 0.3.0 to 0.3.1
